### PR TITLE
feat: query params are sorted on the URL

### DIFF
--- a/addon/services/query-params.ts
+++ b/addon/services/query-params.ts
@@ -68,7 +68,7 @@ export default class QueryParamsService extends Service {
     const { protocol, host, pathname, search, hash } = window.location;
     const queryParams = this.byPath[path];
     const existing = qs.parse(search.split('?')[1]);
-    const query = qs.stringify({ ...existing, ...queryParams });
+    const query = qs.stringify(sortKeys({ ...existing, ...queryParams }));
     const newUrl = `${protocol}//${host}${pathname}${hash}${isPresent(query) ? '?' : ''}${query}`;
 
     window.history.replaceState({ path: newUrl }, '', newUrl);
@@ -96,13 +96,23 @@ export default class QueryParamsService extends Service {
   }
 }
 
+function sortKeys(unordered: Record<string, unknown>): Record<string, unknown> {
+  return Object.keys(unordered)
+    .sort()
+    .reduce((obj, key) => {
+      obj[key] = unordered[key];
+
+      return obj;
+    }, {});
+}
+
 const queryParamHandler = {
   get(obj: any, key: string, ...rest: any[]) {
     return Reflect.get(obj, key, ...rest);
   },
   set(obj: any, key: string, value: any, ...rest: any[]) {
     let { protocol, host, pathname } = window.location;
-    let query = qs.stringify({ ...obj, [key]: value });
+    let query = qs.stringify(sortKeys({ ...obj, [key]: value }));
     let newUrl = `${protocol}//${host}${pathname}${isPresent(query) ? '?' : ''}${query}`;
 
     window.history.pushState({ path: newUrl }, '', newUrl);

--- a/tests/acceptance/navigation-test.ts
+++ b/tests/acceptance/navigation-test.ts
@@ -233,5 +233,32 @@ module('Acceptance | Navigation', function (hooks) {
     });
   });
 
+  module('query param is reflected in the URL sorted', function (hooks) {
+    let service: QueryParamsService;
+
+    hooks.beforeEach(function () {
+      service = getQPService();
+    });
+
+    test('setting params', function (assert) {
+      service.current.delta = '4';
+      service.current.beta = '2';
+
+      let indexDelta = window.location.search.indexOf('delta');
+      let indexBeta = window.location.search.indexOf('beta');
+
+      assert.ok(indexBeta < indexDelta, 'params are sorted');
+    });
+
+    test('visiting a route', async function (assert) {
+      await visit('/bar?b=4&a=2');
+
+      let indexB = window.location.search.indexOf('b');
+      let indexA = window.location.search.indexOf('a');
+
+      assert.ok(indexA < indexB, 'params are sorted');
+    });
+  });
+
   module('locationType is the default and there is a hash in the URL', function () {});
 });


### PR DESCRIPTION
The ensures that the params are sorted on the URL

Some might consider this a breaking change. But your not on 1.0.0 yet so.....

Fixes https://github.com/NullVoxPopuli/ember-query-params-service/issues/401